### PR TITLE
Decorators support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Arguments from path and query
    if __name__ == "__main__":
        web.run_app(app)
 
-There is no more ``request`` object in handler only required arguments.
+There is no ``request`` object in handler signature anymore - only required arguments.
    
 
 Body with schema
@@ -94,10 +94,39 @@ Use aiohug_swagger_ package.
 .. _aiohug_swagger: https://github.com/nonamenix/aiohug_swagger
 
 
+Decorators
+----------
+
+Because of the way ``aiohttp`` routing works all decorators to resource handlers
+must be applied **BEFORE** ``aiohug``'s routing decorator, i.e.
+
+.. code:: python
+
+   def some_decorator(func):
+
+    @wraps(func)
+    def wrapper(request, *args, **kwargs):
+        # Some logic for decorator
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+    @routes.get("/ping/")
+    @some_decorator
+    async def hello():
+        return "pong"
+
+
+Moreover, make sure to decorate wrapper functions with ``wraps`` decorator from ``functools`` module
+- otherwise ``aiohug`` won't be able to access original handler's arguments and annotations.
+
+
+
 Why aiohug?
 ===========
 
-It's just hug_ API implementation for aiohttp 
+It's just hug_ API implementation for ``aiohttp``
 
 .. _hug: https://github.com/timothycrosley/hug
 

--- a/aiohug/arguments.py
+++ b/aiohug/arguments.py
@@ -65,6 +65,13 @@ def cast_arg(arg, kind: Optional = None):
 
 
 async def get_kwargs(request: web.Request, handler):
+    # unwrap all decorators if there are any
+    while True:
+        wrapped = getattr(handler, "__wrapped__", None)
+        if wrapped is None:
+            break
+        handler = wrapped
+
     defaults = get_default_args(handler)
     arg_spec = getfullargspec(handler)
     kwargs = {}

--- a/aiohug/tests/test_decorators.py
+++ b/aiohug/tests/test_decorators.py
@@ -1,0 +1,57 @@
+from functools import wraps
+
+from aiohttp import web
+
+from aiohug import RouteTableDef
+
+
+def create_app():
+    app = web.Application()
+    return app
+
+
+def decorator(func):
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        result = await func(*args, **kwargs)
+        return f"a_{result}"
+
+    return wrapper
+
+
+async def test_decorator(aiohttp_client):
+    routes = RouteTableDef()
+
+    @routes.get("/ping/")
+    @decorator
+    async def hello():
+        return "pong"
+
+    app = create_app()
+    app.add_routes(routes)
+
+    client = await aiohttp_client(app)
+    resp = await client.get("/ping/")
+    assert resp.status == 200
+    text = await resp.text()
+    assert "a_pong" in text
+
+
+async def test_multiple_decorators(aiohttp_client):
+    routes = RouteTableDef()
+
+    @routes.get("/ping/")
+    @decorator
+    @decorator
+    @decorator
+    async def hello():
+        return "pong"
+
+    app = create_app()
+    app.add_routes(routes)
+
+    client = await aiohttp_client(app)
+    resp = await client.get("/ping/")
+    assert resp.status == 200
+    text = await resp.text()
+    assert "a_a_a_pong" in text

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,37 @@
+# 0.6.2
+
+* Support decorators for handlers
+
+```python
+from functools import wraps
+from aiohug import RouteTableDef
+
+routes = RouteTableDef()
+
+def some_decorator(func):
+    
+    @wraps(func)
+    def wrapper(request, *args, **kwargs):
+        # Some logic for decorator
+        return func(*args, **kwargs)
+    
+    return wrapper
+    
+
+@routes.get("/ping/")
+@some_decorator
+async def hello():
+    return "pong"
+
+```
+
 # 0.6.1
 
 * Support prefix for handlers
 
 ```python
+from aiohug import RouteTableDef
+
 monitoring_routes = RouteTableDef(prefix="monitoring")
 
 @monitoring_routes.get("/ping/")

--- a/project.ini
+++ b/project.ini
@@ -1,5 +1,5 @@
 [project]
 url = https://github.com/nonamenix/aiohug
-version = 0.6.1
+version = 0.6.2
 name = aiohug
 description = aiohug


### PR DESCRIPTION
Added support for decorators:
```python
def some_decorator(func):
    @wraps(func)
    def wrapper(request, *args, **kwargs):
        # Some logic for decorator
        return func(*args, **kwargs)
    return wrapper

@routes.get("/ping/")
@some_decorator
async def hello():
    return "pong"
```